### PR TITLE
Fix Sentrizeal's Alternate Avatar Pack Options

### DIFF
--- a/App/Config/BG1EE/InstallOrder.ini
+++ b/App/Config/BG1EE/InstallOrder.ini
@@ -517,13 +517,13 @@ ANN;#10 is IWD casting graphics
 STD;iwdification;10;09;0000;
 ANN;#20 is commoners use drab colors
 STD;iwdification;20;09;0000;
-STD;Sentrizeal_AA_Pack;0;13;0000;
-STD;Sentrizeal_AA_Pack;1;13;0000;
 STD;Sentrizeal_AA_Pack;2;13;0000;
 STD;Sentrizeal_AA_Pack;3;13;0000;
 STD;Sentrizeal_AA_Pack;4;13;0000;
 STD;Sentrizeal_AA_Pack;5;13;0000;
 STD;Sentrizeal_AA_Pack;6;13;0000;
+STD;Sentrizeal_AA_Pack;7;13;0000;
+STD;Sentrizeal_AA_Pack;8;13;0000;
 ANN;--- spells ---
 STD;spell_rev;10;09;0000;
 STD;spell_rev;20;09;0000;

--- a/App/Config/Global/sentrizeal_aa_pack.ini
+++ b/App/Config/Global/sentrizeal_aa_pack.ini
@@ -9,13 +9,13 @@ Size=5567757
 Tra=EN:0,--:0
 
 [WeiDU-EN]
-@0=Sentrizeal's Wizard 4 Missing Animation Fix
-@1=Sentrizeal's Elven Ranger Avatar (Female)
-@2=Sentrizeal's Elven Ranger Avatar (Male)
-@3=Sentrizeal's Elven Ranger Weapon Fix
-@4=Sentrizeal's Human Gladiator Avatar (Female)
-@5=Sentrizeal's Human Gladiator Avatar (Male)
-@6=Sentrizeal's Human Mercenary Avatar (Female)
+@2=Sentrizeal's Wizard 4 Missing Animation Fix
+@3=Sentrizeal's Elven Ranger Avatar (Female)
+@4=Sentrizeal's Elven Ranger Avatar (Male)
+@5=Sentrizeal's Elven Ranger Weapon Fix
+@6=Sentrizeal's Human Gladiator Avatar (Female)
+@7=Sentrizeal's Human Gladiator Avatar (Male)
+@8=Sentrizeal's Human Mercenary Avatar (Female)
 Tra=0
 
 [Description]


### PR DESCRIPTION
Sentinel's TP2 file has BEGIN sections @2 to @8 (I'm not a weidu expert at all). Here is how the TRA file looks like:

@0  = ~Transferring files...~
@1  = ~Setup complete.~
@2  = ~Sentrizeal's Wizard 4 Missing Animation Fix~
@3  = ~Sentrizeal's Elven Ranger Avatar (Female)~
@4  = ~Sentrizeal's Elven Ranger Avatar (Male)~
@5  = ~Sentrizeal's Elven Ranger Weapon Fix~
@6  = ~Sentrizeal's Human Gladiator Avatar (Female)~
@7  = ~Sentrizeal's Human Gladiator Avatar (Male)~
@8  = ~Sentrizeal's Human Mercenary Avatar (Female)~

Changed to use @2-@8 instead of @0-@6...