### PR TITLE
fix(binaries): Linux binaries support 

### DIFF
--- a/App/Config/Translation-EN.ini
+++ b/App/Config/Translation-EN.ini
@@ -400,13 +400,13 @@ L3=The "Baldur's Gate II" folder you entered does not contain a current version.
 
 [TE-BG1EE]
 L1=The "Baldur's Gate - Enhanced Edition" folder you entered does not exist.|Please double check what you entered.
-L2=The "Baldur's Gate - Enhanced Edition" folder you entered does not contain the expected folder-structure.|Please select the folder containing the Baldur.exe or SiegeOfDragonspear.exe.
+L2=The "Baldur's Gate - Enhanced Edition" folder you entered does not contain the expected folder-structure.|Please select the folder containing the Baldur.exe or SiegeOfDragonspear.exe or for linux BaldursGate.
 L3=The GoG and Steam Editions of Siege of Dragonspear are packaged in a way that does not work with mods. You must run a tool called MODMERGE that will unpack the expansion so that mods can be installed afterwards. You can find MODMERGE at https://github.com/ScottBrooks/modmerge/releases - download modmerge-win32.zip, take the modmerge.exe program and put it in your BGEE folder, run it there, and follow the prompts. After the tool is finished, you will be able to install mods manually or with assistence.
 L4=You have provided a "Baldur's Gate - Enhanced Edition" folder path, implying that you want to install the Enhanced Edition Trilogy that combines BG1EE and BG2EE. However, you have not installed the Siege of Dragonspear expansion that is required for the Enhanced Edition Trilogy. If you do not have the expansion, set the BG1EE folder to '-' to indicate that you are only installing mods for BG2EE.
 
 [TE-BG2EE]
 L1=The "Baldur's Gate II - Enhanced Edition" folder you entered does not exist.|Please double check what you entered.
-L2=The "Baldur's Gate II - Enhanced Edition" folder you entered does not contain the expected folder-structure. Please select the folder containing the Baldur.exe.
+L2=The "Baldur's Gate II - Enhanced Edition" folder you entered does not contain the expected folder-structure. Please select the folder containing the Baldur.exe  or for linux BaldursGateII.
 
 [TE-IWD1]
 L1=The "Icewind Dale" folder you entered does not exist.|Please double check what you entered.
@@ -565,7 +565,7 @@ Seperate[2][1]=Directories
 Static[2][1]=Baldur's Gate
 Static[2][3]=Downloads
 Seperate[2][2]=Customization
-Static[2][4]=Make your selection of mods 
+Static[2][4]=Make your selection of mods
 Static[2][5]=Translations
 ; PreSel
 Seperate[3][1]=Backup

--- a/App/Includes/17_Testing.au3
+++ b/App/Includes/17_Testing.au3
@@ -497,13 +497,13 @@ Func _Test_CheckRequiredFiles_BG1EE()
 		_Test_SetButtonColor(1, 0, 0); green
 		Return SetError(0, 0, 2)
 	EndIf
-    	 
+
     If Not FileExists($g_BG1EEDir) Or $g_BG1EEDir = '' Then
 		_Misc_MsgGUI(4, $g_ProgName, _GetTR($Message, 'L1'), 1); => folder does not exist
 		_Test_SetButtonColor($Num, 1, 1); red
 		Return SetError(1, 1, 1)
 	EndIf
-	If FileExists($g_BG1EEDir&'\lang\en_US') And FileExists($g_BG1EEDir&'\movies\mineflod.wbm') And ((FileExists($g_BG1EEDir&'\Baldur.exe') or FileExists($g_BG1EEDir&'\SiegeOfDragonspear.exe'))) Then; BG1EE-directory structure
+	If FileExists($g_BG1EEDir&'\lang\en_US') And FileExists($g_BG1EEDir&'\movies\mineflod.wbm') And ((FileExists($g_BG1EEDir&'\Baldur.exe') or FileExists($g_BG1EEDir&'\SiegeOfDragonspear.exe') or FileExists($g_BG1EEDir&'\BaldursGate'))) Then; BG1EE-directory structure
 	    If $g_Flags[14] = 'BG2EE' And Not FileExists($g_BG1EEDir&'\movies\sodcin01.wbm') And Not FileExists($g_BG1EEDir&'\sod-dlc.zip') And Not FileExists($g_BG1EEDir&'\dlc\sod-dlc.zip') Then
 			_Misc_MsgGUI(4, $g_ProgName, _GetTR($Message, 'L4'), 1); => SoD is required for EET install
 			_Test_SetButtonColor($Num, 1, 1); red
@@ -541,7 +541,7 @@ Func _Test_CheckRequiredFiles_BG2EE()
 		_Test_SetButtonColor(2, 1, 1)
 		Return SetError(1, 1, 1)
 	EndIf
-	If FileExists($g_BG2EEDir&'\lang\en_US') And FileExists($g_BG2EEDir&'\movies\melissan.wbm') And FileExists($g_BG2EEDir&'\Baldur.exe') Then; BG2EE-directory structure
+	If FileExists($g_BG2EEDir&'\lang\en_US') And FileExists($g_BG2EEDir&'\movies\melissan.wbm') And (FileExists($g_BG2EEDir&'\Baldur.exe') or FileExists($g_BG2EEDir&'\BaldursGateII')) Then; BG2EE-directory structure
 	Else
 		$Error&=_GetTR($Message, 'L2')&@CRLF; => structure not valid
 	EndIf
@@ -823,7 +823,7 @@ EndFunc   ;==>_Test_GetCustomTP2
 Func _Test_Get_EET_Mods(); called by _Tree_EndSelection() just before starting an installation
 	Local $BG1EE_Mods='WeiDU|bwinstallpack|bwtrimpack|bwfixpack|bwtextpack|bwtextpackp|'; trailing | is needed
 	Local $BG2EE_Mods=$BG1EE_Mods&'|'; trailing | is needed
-	; mods in the above list will still be skipped at install time, if purge rules exclude them (e.g., bwtextpackP is for RU installs only) 
+	; mods in the above list will still be skipped at install time, if purge rules exclude them (e.g., bwtextpackP is for RU installs only)
 	$g_Flags[21]=''; will contain BG1-mods in EET -> Empty means no BG1-install
 	$g_Flags[22]=''; will contain BG2-mods in EET
 	If Not StringInStr($g_GConfDir, 'BG2EE') Then Return


### PR DESCRIPTION
Linux binaries are not named Baldur.exe updated scripts to reflect this with an additional or option.

Signed-off-by: dark0dave <dark0dave@mykolab.com>