### PR TITLE
fix(binaries): Linux binaries fix for IWD and PST

### DIFF
--- a/App/Config/Translation-EN.ini
+++ b/App/Config/Translation-EN.ini
@@ -421,12 +421,12 @@ L2=The "Icewind Dale II" folder you entered does not contain a current version. 
 
 [TE-IWD1EE]
 L1=The "IceWind Dale - Enhanced Edition" folder you entered does not exist.|Please double check what you entered.
-L2=The "IceWind Dale - Enhanced Edition" folder you entered does not contain the expected folder-structure. Please select the folder containing the IceWind.exe.
+L2=The "IceWind Dale - Enhanced Edition" folder you entered does not contain the expected folder-structure. Please select the folder containing the IceWind.exe or for linux icewinddale.
 L3=The "Icewind Dale" folder you entered contains an unpatched installation.|Please install at least patch 2.0.
 
 [TE-PSTEE]
 L1=The "Planescape Torment - Enhanced Edition" folder you entered does not exist.|Please double check what you entered.
-L2=The "Planescape Torment - Enhanced Edition" folder you entered does not contain the expected folder-structure. Please select the folder containing the Torment.exe.
+L2=The "Planescape Torment - Enhanced Edition" folder you entered does not contain the expected folder-structure. Please select the folder containing the Torment.exe or for linux Torment64.
 
 [TE-PST]
 L1=The "Planescape: Torment" folder you entered does not exist.|Please double check what you entered.

--- a/App/Includes/17_Testing.au3
+++ b/App/Includes/17_Testing.au3
@@ -648,7 +648,7 @@ Func _Test_CheckRequiredFiles_IWD1EE()
 		_Test_SetButtonColor(2, 1, 1)
 		Return SetError(1, 1, 1)
 	EndIf
-	If FileExists($g_IWD1EEDir&'\lang\en_US') And FileExists($g_IWD1EEDir&'\movies\avalanch.wbm') And FileExists($g_IWD1EEDir&'\icewind.exe') Then; IWD1EE-directory structure
+	If FileExists($g_IWD1EEDir&'\lang\en_US') And ((FileExists($g_IWD1EEDir&'\movies\avalanch.wbm') And FileExists($g_IWD1EEDir&'\icewind.exe')) or FileExists($g_IWD1EEDir&'\icewinddale')) Then; IWD1EE-directory structure
 	Else
 		$Error&=_GetTR($Message, 'L2')&@CRLF; => structure not valid
 	EndIf
@@ -681,7 +681,7 @@ Func _Test_CheckRequiredFiles_PSTEE()
 		_Test_SetButtonColor(2, 1, 1)
 		Return SetError(1, 1, 1)
 	EndIf
-	If FileExists($g_PSTEEDir&'\lang\en_US') And FileExists($g_PSTEEDir&'\data\profiles.bif') And FileExists($g_PSTEEDir&'\Torment.exe') Then; PSTEE-directory structure
+	If FileExists($g_PSTEEDir&'\lang\en_US') And FileExists($g_PSTEEDir&'\data\profiles.bif') And (FileExists($g_PSTEEDir&'\Torment.exe') or FileExists($g_PSTEEDir&'\Torment64')) Then; PSTEE-directory structure
 	Else
 		$Error&=_GetTR($Message, 'L2')&@CRLF; => structure not valid
 	EndIf


### PR DESCRIPTION
Linux binaries are not named Torment.exe or icewind.exe updated scripts to reflect this.