### PR TITLE
Chatty Imoen mod update

### DIFF
--- a/App/Config/Global/chattyimoen.ini
+++ b/App/Config/Global/chattyimoen.ini
@@ -2,10 +2,10 @@
 Name=Chatty Imoen
 Rev=1.5
 Type=S,T,E
-Link=https://github.com/AstroBryGuy/ChattyImoen
-Down=https://github.com/AstroBryGuy/ChattyImoen/archive/refs/tags/v1.5.zip
-Save=ChattyImoen-v1.5.zip
-Size=7456286
+Link=https://github.com/The-Gate-Project/ChattyImoen
+Down=https://github.com/The-Gate-Project/ChattyImoen/archive/refs/tags/v1.5.zip
+Save=ChattyImoen-1.5.zip
+Size=6552610
 Tra=EN:0,FR:1,GE:2,IT:3,PO:4,RU:5
 
 [Description]

--- a/App/Includes/07_Extract.au3
+++ b/App/Includes/07_Extract.au3
@@ -683,9 +683,9 @@ Func Au3ExFix($p_Num)
 		FileWrite($g_LogFile, '>Portraits-Portraits-Everywhere-master\* .' & @CRLF)
 		_Extract_MoveMod('Portraits-Portraits-Everywhere-master')
 	EndIf
-	If StringRegExp($g_Flags[14], 'BWS|BG1EE|BG2EE|PSTEE|IWD1EE') And FileExists($g_GameDir&'\ChattyImoen-v1.5') Then
-		FileWrite($g_LogFile, '>ChattyImoen-v1.5\* .' & @CRLF)
-		_Extract_MoveMod('ChattyImoen-v1.5')
+	If StringRegExp($g_Flags[14], 'BWS|BG1EE|BG2EE|PSTEE|IWD1EE') And FileExists($g_GameDir&'\ChattyImoen-1.5') Then
+		FileWrite($g_LogFile, '>ChattyImoen-1.5\* .' & @CRLF)
+		_Extract_MoveMod('ChattyImoen-1.5')
 	EndIf
 	If StringRegExp($g_Flags[14], 'BWS|BG1EE|BG2EE|PSTEE|IWD1EE') And FileExists($g_GameDir&'\iwdification-5') Then
 		FileWrite($g_LogFile, '>iwdification-5\* .' & @CRLF)


### PR DESCRIPTION
The [old download url](https://github.com/AstroBryGuy/ChattyImoen/archive/refs/tags/v1.5.zip) for ChattyImoen is no longer valid, because the author deleted the full github account.

I was going to submit this pull request a few days before it was deleted. The filename when downloading the mod from github was "ChattyImoen-1.5.zip", and the code said "ChattyImoen-v1.5.zip" (the v is missing). As a result of that, the mod could be downloaded but not installed.

A new location for this mod is [this github](https://github.com/The-Gate-Project/ChattyImoen). Notice how the filename lacks the letter "v", as I just said. I have updated the files 07_Extract.au3 and chattyimoen.ini need to make it work.

I have tested this myself, and the mod gets installed without any errors. The whole discussion about the mod disappearing is [here](https://www.gibberlings3.net/forums/topic/31321-eet-mod-install-order-guide-wip/?do=findComment&comment=329769)